### PR TITLE
Made perplexcpp into shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(
-  perplexcpp 
+  perplexcpp SHARED
 
   c_interface.f
   utils.cc 


### PR DESCRIPTION
This is important because otherwise it cannot be used in other builds
because -fPIC is not set.